### PR TITLE
fix(list): paginate `feed/v3` with the real opaque cursor

### DIFF
--- a/src/api/feed.rs
+++ b/src/api/feed.rs
@@ -3,14 +3,11 @@ use super::types::{FeedFilters, FeedResponse, FeedV3Request};
 use crate::errors::CliError;
 
 impl SunoClient {
-    /// List songs using feed/v3 with optional search and filters.
-    pub async fn feed(&self, page: u32) -> Result<FeedResponse, CliError> {
+    /// List songs using feed/v3. `cursor` is the UUID of the last clip from the
+    /// previous page (use `None` for the first page).
+    pub async fn feed(&self, cursor: Option<String>) -> Result<FeedResponse, CliError> {
         let req = FeedV3Request {
-            cursor: if page > 0 {
-                Some(page.to_string())
-            } else {
-                None
-            },
+            cursor,
             limit: Some(20),
             filters: None,
         };

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -106,10 +106,8 @@ pub struct ClipMetadata {
 pub struct FeedResponse {
     #[serde(default)]
     pub clips: Vec<Clip>,
-    #[allow(dead_code)]
     pub next_cursor: Option<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub has_more: bool,
 }
 
@@ -117,6 +115,8 @@ pub struct FeedResponse {
 
 #[derive(Debug, Serialize)]
 pub struct FeedV3Request {
+    /// Opaque cursor (the UUID of the last clip from the previous page).
+    /// Pass `None` for the first page.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -322,9 +322,13 @@ pub struct StemsArgs {
 
 #[derive(clap::Args)]
 pub struct ListArgs {
-    /// Page number (0-indexed)
-    #[arg(short, long, default_value = "0")]
+    /// Page number (0-indexed). Each page holds 20 clips.
+    #[arg(short, long, default_value = "0", conflicts_with = "all")]
     pub page: u32,
+
+    /// Fetch every page and concatenate the results.
+    #[arg(short, long)]
+    pub all: bool,
 }
 
 #[derive(clap::Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,10 +207,48 @@ async fn run() -> Result<(), CliError> {
         }
 
         Commands::List(args) => {
-            let feed = client().await?.feed(args.page).await?;
+            let c = client().await?;
+            // Suno paginates with an opaque cursor (the last clip's UUID); we
+            // walk pages 0..=N for `--page N`, or until exhaustion for `--all`.
+            let mut cursor: Option<String> = None;
+            let mut clips = Vec::new();
+            let mut current_page = 0u32;
+            let mut overshot = false;
+            loop {
+                let resp = c.feed(cursor.take()).await?;
+                let has_more = resp.has_more && resp.next_cursor.is_some();
+
+                if args.all {
+                    clips.extend(resp.clips);
+                } else if current_page == args.page {
+                    clips = resp.clips;
+                    break;
+                }
+
+                if !has_more {
+                    overshot = !args.all && current_page < args.page;
+                    break;
+                }
+                cursor = resp.next_cursor;
+                current_page += 1;
+            }
+
             match fmt {
-                OutputFormat::Json => output::json::success(&feed.clips),
-                OutputFormat::Table => output::table::clips(&feed.clips),
+                OutputFormat::Json => output::json::success(&clips),
+                OutputFormat::Table => {
+                    if overshot {
+                        eprintln!(
+                            "No page {} — only {} page(s) available. Try --page {} or --all.",
+                            args.page,
+                            current_page + 1,
+                            current_page
+                        );
+                    } else if clips.is_empty() {
+                        eprintln!("No clips found.");
+                    } else {
+                        output::table::clips(&clips);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
`suno list --page N` currently returns the same 20 clips as page 0 for any `N`. Root cause: the request body sent `{"cursor": "<N>"}` — a numeric string the server cannot resolve to a clip UUID. Suno's `/api/feed/v3` paginates with an **opaque cursor** (the last clip's UUID from the previous response), exposed as `next_cursor` in the body. That field was declared on `FeedResponse` but marked `#[allow(dead_code)]` and never read, which hid the bug.

This PR walks the real cursor chain, adds `--all` for full-catalog fetches, and improves the empty-result message when the requested page is past the end.

Closes #1 

## Changes

- `src/api/types.rs` — document `cursor` on `FeedV3Request`; remove the now-unused `#[allow(dead_code)]` on `FeedResponse::next_cursor` and `has_more`.
- `src/api/feed.rs` — `feed()` now takes `Option<String>` (the opaque cursor) instead of `u32`. Pass `None` for the first page.
- `src/cli.rs` — keep `--page N` for users; add `--all` (mutually exclusive with `--page`).
- `src/main.rs` — `Commands::List` walks `next_cursor` until either it reaches page `N` or `has_more` is false. In table mode, an overshoot prints a hint instead of an empty table.

## How it works

```rust
let mut cursor: Option<String> = None;
loop {
    let resp = c.feed(cursor.take()).await?;
    let has_more = resp.has_more && resp.next_cursor.is_some();

    if args.all {
        clips.extend(resp.clips);
    } else if current_page == args.page {
        clips = resp.clips;
        break;
    }

    if !has_more {
        overshot = !args.all && current_page < args.page;
        break;
    }
    cursor = resp.next_cursor;
    current_page += 1;
}
```

For `--page N` we make N+1 round-trips (the server has no random-access pagination). `--all` drains until `has_more` is false.

## Test plan

Verified against the live `studio-api-prod.suno.com` API on an account with 102 clips:

```sh
$ suno --json list      | jq -r '.data[].id' | sort > /tmp/p0.txt
$ suno --json list -p 1 | jq -r '.data[].id' | sort > /tmp/p1.txt
$ suno --json list -p 2 | jq -r '.data[].id' | sort > /tmp/p2.txt
$ comm -12 /tmp/p0.txt /tmp/p1.txt | wc -l    # 0  (was 20)
$ comm -12 /tmp/p1.txt /tmp/p2.txt | wc -l    # 0  (was 20)

$ suno --json list --all | jq -r '.data | length'
102

$ suno list -p 99
No page 99 — only 6 page(s) available. Try --page 5 or --all.
```

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no new warnings (one pre-existing warning in `src/captcha.rs:251`, untouched)
- [x] Live: `--page 0..N` returns distinct clip IDs per page
- [x] Live: `--all` returns the full catalog
- [x] Live: overshoot prints a helpful hint in table mode and an empty `data: []` in JSON mode

## Notes for reviewers

- `cursor.take()` avoids cloning the `Option<String>` between iterations — the cursor is consumed by the request and replaced with the next one.
- JSON output is unchanged in shape (`{ version, status, data }`) so existing scripts keep working. The new error message is `eprintln!` only (table mode), so it never leaks into JSON.
- `API_INTELLIGENCE.md:94` documents the request body as `{"page": 0}`, which is incorrect — that field is ignored by the server. Happy to follow up with a doc fix in a separate commit if preferred.
- I did not change `search()`, which already correctly passes `cursor: None` and uses `filters.searchText`. The `--all` flag is intentionally scoped to `list` for now.