### PR TITLE
fix(auth): tolerate current billing/info payload and improve auth JSON errors

### DIFF
--- a/src/api/billing.rs
+++ b/src/api/billing.rs
@@ -7,7 +7,31 @@ impl SunoClient {
         self.with_auth_retry(|| async {
             let resp = self.get("/api/billing/info/").send().await?;
             let resp = self.check_response(resp).await?;
-            Ok(resp.json().await?)
+            let raw = resp.text().await?;
+            let mut info: BillingInfo = serde_json::from_str(&raw).map_err(|e| CliError::Api {
+                code: "billing_schema_drift",
+                message: format!(
+                    "billing/info returned unexpected JSON/body ({e}): {}",
+                    raw.replace(['\n', '\r'], " ")
+                        .chars()
+                        .take(500)
+                        .collect::<String>()
+                ),
+            })?;
+            if info.total_credits_left == 0 {
+                info.total_credits_left = info.credits;
+            }
+            if info.plan.name.is_empty() {
+                info.plan.name = if info.is_active {
+                    "Active".to_string()
+                } else {
+                    "Unknown".to_string()
+                };
+            }
+            if info.plan.plan_key.is_empty() {
+                info.plan.plan_key = info.plan.name.to_ascii_lowercase();
+            }
+            Ok(info)
         })
         .await
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -2,24 +2,35 @@ use serde::{Deserialize, Serialize};
 
 // --- Billing / Account ---
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct BillingInfo {
+    #[serde(default)]
     pub credits: u64,
+    #[serde(default)]
     pub total_credits_left: u64,
+    #[serde(default)]
     pub monthly_usage: u64,
+    #[serde(default)]
     pub monthly_limit: u64,
+    #[serde(default)]
     pub is_active: bool,
+    #[serde(default)]
     pub plan: Plan,
+    #[serde(default)]
     pub models: Vec<Model>,
+    #[serde(default)]
     pub period: String,
+    #[serde(default)]
     pub renews_on: Option<String>,
     #[serde(default)]
     pub remaster_model_types: Vec<RemasterModelInfo>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Plan {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub plan_key: String,
     #[serde(default)]
     pub usage_plan_features: Vec<Feature>,
@@ -30,12 +41,17 @@ pub struct Feature {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Model {
+    #[serde(default)]
     pub name: String,
+    #[serde(default)]
     pub external_key: String,
+    #[serde(default)]
     pub can_use: bool,
+    #[serde(default)]
     pub is_default_model: bool,
+    #[serde(default)]
     pub description: String,
     #[serde(default)]
     pub max_lengths: MaxLengths,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -223,6 +223,16 @@ fn response_excerpt(body: &str) -> String {
     }
 }
 
+fn parse_json_value(body: &str, context: &'static str) -> Result<serde_json::Value, CliError> {
+    serde_json::from_str(body).map_err(|e| CliError::Api {
+        code: "clerk_json_error",
+        message: format!(
+            "{context} returned unexpected JSON/body ({e}): {}",
+            response_excerpt(body)
+        ),
+    })
+}
+
 /// Generate the dynamic browser-token header value.
 pub fn browser_token() -> String {
     let ms = SystemTime::now()
@@ -322,7 +332,8 @@ pub async fn clerk_token_exchange(
         });
     }
 
-    let body: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let raw = resp.text().await.map_err(CliError::Http)?;
+    let body = parse_json_value(&raw, "Clerk session lookup")?;
     let session_id = body
         .get("response")
         .and_then(|r| {
@@ -372,7 +383,8 @@ pub async fn clerk_refresh_jwt(
         });
     }
 
-    let body: serde_json::Value = resp.json().await.map_err(CliError::Http)?;
+    let raw = resp.text().await.map_err(CliError::Http)?;
+    let body = parse_json_value(&raw, "Clerk JWT refresh")?;
     body.get("jwt")
         .and_then(|j| j.as_str())
         .map(String::from)

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,6 +197,9 @@ async fn run() -> Result<(), CliError> {
             } else if let Some(jwt) = args.jwt.clone() {
                 // Legacy: direct JWT paste (expires in ~1 hour)
                 state.jwt = Some(jwt);
+                state.session_id = None;
+                state.cookie = None;
+                state.clerk_client_cookie = None;
                 if state.device_id.is_none() {
                     state.device_id = Some(uuid::Uuid::new_v4().to_string());
                 }


### PR DESCRIPTION
This fixes two issues that block `suno auth --login` against the current Suno web API:

1. `billing/info` now returns a payload shape that no longer guarantees fields like `plan`, `total_credits_left`, `period`, etc.  
   The CLI was treating those as required, so auth appeared to fail even though the Clerk exchange had already succeeded.

2. Clerk auth failures were being surfaced as a generic `error decoding response body`, which made it hard to distinguish a real auth problem from API schema drift.

This patch:

- makes `BillingInfo`, `Plan`, and `Model` more tolerant to missing fields
- falls back from `total_credits_left` to `credits` when needed
- synthesizes a minimal `plan` when Suno omits it
- captures raw response text before JSON parsing for Clerk and billing paths
- turns opaque decode failures into actionable API errors with a response excerpt
- clears stale Clerk session state when `--jwt` is used directly

## Verification

Verified locally against the current live Suno web API:

- `suno auth --login` succeeds
- `suno credits --json` succeeds