### PR TITLE
Fix billing schema drift breaking credits/auth/models

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -9,20 +9,66 @@ pub struct BillingInfo {
     pub monthly_usage: u64,
     pub monthly_limit: u64,
     pub is_active: bool,
-    pub plan: Plan,
+    #[serde(default)]
+    pub is_past_due: bool,
+    /// Suno no longer nests the active plan under a `plan` key. Instead
+    /// `subscription_type` is `false` on the free tier or the plan's
+    /// `plan_key` string (e.g. `"pro"`) when subscribed, and the full catalog
+    /// of plans (with pricing/features) is listed separately in `plans`.
+    #[serde(default)]
+    pub subscription_type: SubscriptionType,
     pub models: Vec<Model>,
-    pub period: String,
-    pub renews_on: Option<String>,
+    #[serde(default)]
+    pub plans: Vec<PlanOption>,
+    #[serde(default)]
+    pub accessible_features: Vec<Feature>,
     #[serde(default)]
     pub remaster_model_types: Vec<RemasterModelInfo>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub struct Plan {
-    pub name: String,
+#[serde(untagged)]
+pub enum SubscriptionType {
+    /// No active paid subscription (free tier).
+    None(bool),
+    /// Active plan, identified by its `plan_key` (e.g. "pro").
+    Plan(String),
+}
+
+impl Default for SubscriptionType {
+    fn default() -> Self {
+        SubscriptionType::None(false)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PlanOption {
     pub plan_key: String,
+    pub name: String,
     #[serde(default)]
     pub usage_plan_features: Vec<Feature>,
+}
+
+impl BillingInfo {
+    /// Human-readable name of the account's current plan, resolved from
+    /// `subscription_type` against the `plans` catalog (falls back to the
+    /// raw plan key, or "Free" when there's no active subscription).
+    pub fn plan_name(&self) -> String {
+        match &self.subscription_type {
+            SubscriptionType::Plan(key) => self
+                .plans
+                .iter()
+                .find(|p| &p.plan_key == key)
+                .map(|p| p.name.clone())
+                .unwrap_or_else(|| key.clone()),
+            SubscriptionType::None(_) => self
+                .plans
+                .iter()
+                .find(|p| p.plan_key == "free")
+                .map(|p| p.name.clone())
+                .unwrap_or_else(|| "Free".to_string()),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,7 +221,8 @@ async fn run() -> Result<(), CliError> {
             }
             eprintln!(
                 "Authenticated! Plan: {}, Credits: {}",
-                info.plan.name, info.total_credits_left
+                info.plan_name(),
+                info.total_credits_left
             );
         }
 
@@ -609,7 +610,8 @@ async fn run() -> Result<(), CliError> {
                             let info = client.billing_info().await?;
                             eprintln!(
                                 "Auth: OK — {}, {} credits",
-                                info.plan.name, info.total_credits_left
+                                info.plan_name(),
+                                info.total_credits_left
                             );
                         }
                         Err(CliError::AuthExpired) => {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -37,17 +37,13 @@ pub fn billing(info: &BillingInfo) {
         .apply_modifier(UTF8_ROUND_CORNERS)
         .set_header(vec!["Field", "Value"]);
 
-    table.add_row(vec!["Plan", &info.plan.name]);
+    table.add_row(vec!["Plan", &info.plan_name()]);
     table.add_row(vec!["Credits Left", &info.total_credits_left.to_string()]);
     table.add_row(vec![
         "Monthly Usage",
         &format!("{} / {}", info.monthly_usage, info.monthly_limit),
     ]);
     table.add_row(vec!["Active", &info.is_active.to_string()]);
-    table.add_row(vec!["Period", &info.period]);
-    if let Some(ref renew) = info.renews_on {
-        table.add_row(vec!["Renews On", renew]);
-    }
     println!("{table}");
 }
 


### PR DESCRIPTION
## Why

Suno's `/api/billing/info/` endpoint has drifted from the schema this CLI expects. It no longer returns a nested `plan: { name, plan_key }` object or a `period` string — both were required fields on the Rust `BillingInfo` struct, so every command that touches billing (`credits`, `auth`, `config check`, `models`, etc.) failed to deserialize the response and errored out.

The live response now exposes `subscription_type` (either `false` for the free tier, or the active plan's `plan_key` string) plus a `plans` array describing the full catalog (id, key, name, pricing, features). Verified by making an authenticated live call against the real API and inspecting the current JSON shape.

## What changed

- `src/api/types.rs`: replaced the required `plan`/`period`/`renews_on` fields on `BillingInfo` with `subscription_type: SubscriptionType` (an untagged enum over `bool`/`String`) and `plans: Vec<PlanOption>`, matching the current API. Added a `BillingInfo::plan_name()` helper that resolves a human-readable plan name from `subscription_type` against the `plans` catalog (falls back to the raw key, or "Free").
- `src/main.rs`: updated the two call sites that read `info.plan.name` to use the new `plan_name()` helper.
- `src/output/table.rs`: updated the `credits` table renderer to use `plan_name()` and dropped the now-nonexistent `Period`/`Renews On` rows.

## Testing

Built and ran the CLI locally against the live Suno API with a real authenticated session — `suno credits`, `suno models`, and `suno config check` all now succeed and render correctly (previously they failed with a deserialization error).

This is split out from a larger local commit so the critical fix can be reviewed/merged independently of the unrelated `--title`/`v4.5-all` additions (see companion PR).
